### PR TITLE
Implements repository for ridership

### DIFF
--- a/src/spbus/adapters/sptrans.clj
+++ b/src/spbus/adapters/sptrans.clj
@@ -97,7 +97,7 @@
        (filter #(= (:date %) (time/local-date date)))
        (first)))
 
-(defn ^:private row->route-statistics
+(defn ^:private parse-row-statistics
   [raw-row]
   (let [row (seq raw-row)]
     (cond
@@ -105,9 +105,14 @@
       (parser-b/parseable? row) (parser-b/parse row)
       :else (throw (ex-info "No suitable parser" {:row row})))))
 
+(defn ^:private row->route-statistics
+  [raw-row date]
+  (-> (parse-row-statistics raw-row)
+      (assoc :date (str date))))
+
 (defn ^:private all-statistics
-  [rows]
-  (map row->route-statistics rows))
+  [rows date]
+  (map #(row->route-statistics % date) rows))
 
 (defn link->statistics
   "Parses all available statistics based on a given link. These statistics
@@ -115,4 +120,4 @@
   [link]
   (-> (spreadsheet/load-sheet (:url link))
       (spreadsheet/rows :header-size 3)
-      (all-statistics)))
+      (all-statistics (:date link))))

--- a/src/spbus/adapters/sptrans/parser_a.clj
+++ b/src/spbus/adapters/sptrans/parser_a.clj
@@ -134,26 +134,32 @@
 
 (defn basic-info
   [row]
-  (let [id (line-id row)]
-    {:company (company row)
-     :area (area row)
-     :line-id id
-     :line-code (line-code id)
-     :branch-code (branch-code id)
-     :transport-mode "bus"}))
+  {:company (company row)
+    :area (area row)
+    :transport-mode "bus"})
 
 (defn with-pre-boarding
   [data row]
   (merge data {:pre-boarding (pre-boarding? row)}))
 
+(defn with-stop-details
+  [data row]
+  (if (pre-boarding? row)
+    (merge data {:stop-name (route row)
+                 :stop-id (line-id row)})
+    data))
+
 (defn with-route-details
   [data row]
-  (merge data (if (pre-boarding? row)
-                  {:route (route row)
-                   :terminus (main-terminus row)}
-                  {:route (route row)
+  (let [id (line-id row)]
+    (if (pre-boarding? row)
+      data
+      (merge data {:route (route row)
                    :main-terminus (main-terminus row)
-                   :auxiliar-terminus (auxiliar-terminus row)})))
+                   :auxiliar-terminus (auxiliar-terminus row)
+                   :line-id id
+                   :line-code (line-code id)
+                   :branch-code (branch-code id)}))))
 
 (defn with-pax-totals
   [data row]
@@ -175,5 +181,6 @@
   [row]
   (-> (basic-info row)
       (with-pre-boarding row)
+      (with-stop-details row)
       (with-route-details row)
       (with-pax-totals row)))

--- a/src/spbus/adapters/sptrans/parser_b.clj
+++ b/src/spbus/adapters/sptrans/parser_b.clj
@@ -146,26 +146,32 @@
 
 (defn basic-info
   [row]
-  (let [id (line-id row)]
-    {:transport-mode "bus"
-     :company (company row)
-     :area (area row)
-     :line-id id
-     :line-code (line-code id)
-     :branch-code (branch-code id)}))
+  {:company (company row)
+   :area (area row)
+   :transport-mode "bus"})
 
 (defn with-pre-boarding
   [data row]
   (merge data {:pre-boarding (pre-boarding? row)}))
 
+(defn with-stop-details
+  [data row]
+  (if (pre-boarding? row)
+    (merge data {:stop-name (route row)
+                 :stop-id (line-id row)})
+    data))
+
 (defn with-route-details
   [data row]
-  (merge data (if (pre-boarding? row)
-                  {:route (route row)
-                   :terminus (main-terminus row)}
-                  {:route (route row)
+  (let [id (line-id row)]
+    (if (pre-boarding? row)
+      data
+      (merge data {:route (route row)
                    :main-terminus (main-terminus row)
-                   :auxiliar-terminus (auxiliar-terminus row)})))
+                   :auxiliar-terminus (auxiliar-terminus row)
+                   :line-id id
+                   :line-code (line-code id)
+                   :branch-code (branch-code id)}))))
 
 (defn with-pax-totals
   [data row]
@@ -190,5 +196,6 @@
   [row]
   (-> (basic-info row)
       (with-pre-boarding row)
+      (with-stop-details row)
       (with-route-details row)
       (with-pax-totals row)))

--- a/src/spbus/components/storage.clj
+++ b/src/spbus/components/storage.clj
@@ -71,7 +71,8 @@
   [db entity conditions]
   (if (empty? conditions)
     (fail/fail "Can not delete without conditions")
-    (monger-data/remove db entity conditions)))
+    (let [result (monger-data/remove db entity conditions)]
+      (.getN result))))
 
 (defrecord MongoStorage [config conn db]
   component/Lifecycle

--- a/src/spbus/db/ridership.clj
+++ b/src/spbus/db/ridership.clj
@@ -1,0 +1,33 @@
+(ns spbus.db.ridership
+  (:require [spbus.protocols.storage-client :as client])
+  (:gen-class))
+
+(def entity "ridership")
+
+(defn ridership-with-id
+  [storage doc-id]
+  (client/find-by-id storage entity doc-id))
+
+(defn riderships
+  [storage conditions]
+  (client/find storage entity conditions))
+
+(defn add-ridership
+  [storage doc]
+  (client/insert storage entity doc))
+
+(defn update-ridership
+  [storage doc-id updated-document]
+  (client/update storage entity doc-id updated-document))
+
+(defn upsert-ridership
+  [storage doc]
+  (let [doc-id (:_id doc)
+        doc-in-db (ridership-with-id storage doc-id)]
+    (if (some? doc-in-db)
+      (update-ridership storage doc-id doc)
+      (add-ridership storage doc))))
+
+(defn delete-ridership
+  [storage doc-id]
+  (client/delete storage entity {:_id doc-id}))

--- a/src/spbus/db/ridership.clj
+++ b/src/spbus/db/ridership.clj
@@ -1,8 +1,17 @@
 (ns spbus.db.ridership
-  (:require [spbus.protocols.storage-client :as client])
+  (:require [monger.operators :refer :all]
+            [spbus.protocols.storage-client :as client]
+            [clojure.string :as string])
   (:gen-class))
 
 (def entity "ridership")
+(def text-search-keys [:line-id :line-code :branch-code
+                       :main-terminus :auxiliar-terminus
+                       :company :stop-name :stop-id])
+
+(defn ^:private regex-match-field
+  [field terms]
+  {field {$regex (str ".*" (string/upper-case terms) ".*")}})
 
 (defn ridership-with-id
   [storage doc-id]
@@ -12,13 +21,18 @@
   [storage conditions]
   (client/find storage entity conditions))
 
+(defn text-search
+  [storage terms]
+  (let [query (map #(regex-match-field % terms) text-search-keys)]
+    (client/find storage entity {$or query})))
+
 (defn add-ridership
   [storage doc]
   (client/insert storage entity doc))
 
 (defn update-ridership
   [storage doc-id updated-document]
-  (client/update storage entity doc-id updated-document))
+  (client/update-by-id storage entity doc-id updated-document))
 
 (defn upsert-ridership
   [storage doc]

--- a/src/spbus/protocols/storage_client.clj
+++ b/src/spbus/protocols/storage_client.clj
@@ -10,7 +10,9 @@
     "Returns a collection of objects based on given conditions.")
   (insert [storage entity data]
     "Insert a new object to database under given entity.")
-  (update [storage entity id updated-data]
-    "Merges updated-data into the data already persisted to database at given ID.")
+  (update-by-id [storage entity id updated-data]
+    "Merges updated-data into the data already persisted to database given an identifier.")
+  (delete-by-id [storage entity id]
+    "Removes a single record from database given an identifier.")
   (delete [storage entity conditions]
-    "Removes a record from database."))
+    "Removes a batch of records from database."))

--- a/src/spbus/protocols/storage_client.clj
+++ b/src/spbus/protocols/storage_client.clj
@@ -10,6 +10,8 @@
     "Returns a collection of objects based on given conditions.")
   (insert [storage entity data]
     "Insert a new object to database under given entity.")
+  (insert-batch [storage entity coll]
+    "Insert a batch of objects into entity at the same time.")
   (update-by-id [storage entity id updated-data]
     "Merges updated-data into the data already persisted to database given an identifier.")
   (delete-by-id [storage entity id]

--- a/src/spbus/system_utils.clj
+++ b/src/spbus/system_utils.clj
@@ -6,7 +6,8 @@
 (def current-system (atom nil))
 
 (defn stop-system []
-  (swap! current-system #(component/stop %)))
+  (component/stop current-system)
+  (reset! current-system nil))
 
 (defn create-and-start-system
   [env]

--- a/test/factories/ridership/bus-normal.edn
+++ b/test/factories/ridership/bus-normal.edn
@@ -1,0 +1,22 @@
+{:pre-boarding false
+ :line-id "N14311"
+ :line-code "N143"
+ :branch-code "11"
+ :main-terminus "METRO BARRA FUNDA"
+ :auxiliar-terminus "MORRO GRANDE"
+ :route "METRO BARRA FUNDA/MORRO GRANDE"
+ :company "202"
+ :area "1"
+ :paying-pax {:cash 3
+              :normal-and-work-card 35
+              :student 1
+              :month-pass-normal 4
+              :month-pass-work 0
+              :month-pass-student 0
+              :total 43}
+ :free-pax {:bus-bus-connections 18
+            :normal 7
+            :student 1
+            :total 26}
+ :total-pax 69
+ :transport-mode "bus"}

--- a/test/spbus/adapters/sptrans/parser_a_test.clj
+++ b/test/spbus/adapters/sptrans/parser_a_test.clj
@@ -73,10 +73,12 @@
 
 (fact "parser-a/parse returns a map with all information"
   (parser-a/parse row-pre-boarding) => (contains {:pre-boarding true
-                                                  :route "TERM VARGINHA/COOPERPAM"
+                                                  :stop-name "TERM VARGINHA/COOPERPAM"
+                                                  :stop-id "9924PR"
                                                   :transport-mode "bus"})
   (parser-a/parse row-exp-tiradentes) => (contains {:pre-boarding true
-                                                    :terminus "EXP TIRADENTES"
+                                                    :stop-name "EXP TIRADENTES - RUA DO GRITO"
+                                                    :stop-id "510511"
                                                     :transport-mode "bus"})
   (parser-a/parse row-single-terminus) => (contains {:pre-boarding false
                                                      :main-terminus "DETRAN"

--- a/test/spbus/adapters/sptrans/parser_b_test.clj
+++ b/test/spbus/adapters/sptrans/parser_b_test.clj
@@ -77,10 +77,12 @@
 
 (fact "parser-b/parse returns a map with all information"
   (parser-b/parse row-pre-boarding) => (contains {:pre-boarding true
-                                                  :route "TERM CIDADE TIRADENTES/VIP"
+                                                  :stop-name "TERM CIDADE TIRADENTES/VIP"
+                                                    :stop-id "9932PR"
                                                   :transport-mode "bus"})
   (parser-b/parse row-exp-tiradentes) => (contains {:pre-boarding true
-                                                    :route "EXP TIRADENTES - ANA NERI"
+                                                    :stop-name "EXP TIRADENTES - ANA NERI"
+                                                    :stop-id "510513"
                                                     :transport-mode "bus"})
   (parser-b/parse row-bad-format) => (contains {:pre-boarding false
                                                 :main-terminus "PQ RES COCAIA"

--- a/test/spbus/adapters/sptrans_test.clj
+++ b/test/spbus/adapters/sptrans_test.clj
@@ -83,7 +83,7 @@
 
   (against-background (slurp sptrans/statistics-url) => mock-page))
 
-(def mock-link {:url "foo.com"})
+(def mock-link {:url "foo.com" :date "2019-01-20"})
 (def mock-sheet (spreadsheet/load-sheet "./test/fixtures/sptrans/type_a.xls"))
 (def mock-row (seq (spreadsheet/nth-row mock-sheet 0 :header-size 3)))
 
@@ -96,6 +96,6 @@
 
     (fact "parses all rows using proper parser"
       (let [statistics (sptrans/link->statistics mock-link)]
-        (every? #(contains? % :route) statistics) => true)
+        (every? #(contains? % :date) statistics) => true)
       (against-background
        (spreadsheet/load-sheet (:url mock-link)) => mock-sheet)))

--- a/test/spbus/components/storage_test.clj
+++ b/test/spbus/components/storage_test.clj
@@ -7,7 +7,8 @@
             [monger.operators :refer :all]
             [spbus.components.storage :as storage]
             [spbus.protocols.storage-client :as client])
-  (:import clojure.lang.ExceptionInfo))
+  (:import clojure.lang.ExceptionInfo
+           org.bson.types.ObjectId))
 
 (def ^:dynamic *storage* nil)
 (def ^:dynamic *db* nil)
@@ -37,8 +38,7 @@
 
 (facts "about db connection"
   (fact "it fails if no DB name is given at config"
-    (component/start (storage-with-config {}))
-      => (throws ExceptionInfo "Failed connecting to DB"))
+    (component/start (storage-with-config {})) => (throws ExceptionInfo "Failed connecting to DB"))
 
   (fact "it connects to DB whose name is given as config argument"
     (let [db-config {:db-name "test-db"}
@@ -55,30 +55,34 @@
 
     (fact "it assocs :created-at to document being persisted"
       (let [now (time/local-date-time)]
-        (client/insert *storage* test-entity {:foo "bar"})
-          => (contains {:created-at (str now)})
+        (client/insert *storage* test-entity {:foo "bar"}) => (contains {:created-at (str now)})
         (provided (time/local-date-time) => now)))
 
     (fact "it assocs :updated-at to document being persisted"
       (let [now (time/local-date-time)]
-        (client/insert *storage* test-entity {:foo "bar"})
-          => (contains {:updated-at (str now)})
+        (client/insert *storage* test-entity {:foo "bar"}) => (contains {:updated-at (str now)})
         (provided (time/local-date-time) => now))))
 
-  (facts "about update"
+  (facts "about update-by-id"
     (fact "it merges update document into persisted document"
       (let [document (client/insert *storage* test-entity {:foo 1 :bar 2})
             doc-id (:_id document)]
-        (client/update *storage* test-entity doc-id {:foo 0 :baz 3})
-          => (contains {:foo 0
-                        :bar 2
-                        :baz 3})))
+        (client/update-by-id *storage* test-entity doc-id {:foo 0 :baz 3}) => (contains {:foo 0
+                                                                                         :bar 2
+                                                                                         :baz 3})))
+
+    (fact "it updates data even when :_id is given as string"
+      (let [document (client/insert *storage* test-entity {:foo 1})
+            doc-id (.toString (:_id document))]
+        (client/update-by-id *storage* test-entity doc-id {:bar 2}) => (contains {:foo 1
+                                                                                  :bar 2})))
 
     (fact "it touches :updated-at attribute of document being persisted"
       (let [document (client/insert *storage* test-entity {:foo "bar"})
             doc-id (:_id document)]
-        (Thread/sleep 200) ;; forces a time shift so that :updated-at might be updated
-        (client/update *storage* test-entity doc-id {:foo 0})
+        ;; forces a time shift so that :updated-at might be updated
+        (Thread/sleep 200)
+        (client/update-by-id *storage* test-entity doc-id {:foo 0})
         (let [updated-document (client/find-by-id *storage* test-entity doc-id)]
           (:created-at updated-document) => (:created-at document)
           (:updated-at updated-document) =not=> (:updated-at document)))))
@@ -87,33 +91,44 @@
     (fact "finds records using ObjectId instances"
       (let [document (client/insert *storage* test-entity {:foo "bar"})
             doc-id (:_id document)]
-        (client/find-by-id *storage* test-entity doc-id)
-          => (contains {:_id doc-id
-                        :foo "bar"})))
+        (client/find-by-id *storage* test-entity doc-id) => (contains {:_id doc-id
+                                                                       :foo "bar"})))
 
     (fact "finds records using string"
       (let [document (client/insert *storage* test-entity {:foo "bar"})
             doc-id (:_id document)
             string-id (.toString (:_id document))]
-        (client/find-by-id *storage* test-entity string-id)
-          => (contains {:_id doc-id
-                        :foo "bar"}))))
+        (client/find-by-id *storage* test-entity string-id) => (contains {:_id doc-id
+                                                                          :foo "bar"}))))
 
   (facts "about find"
     (fact "finds a collection of records that match given conditions"
       (client/insert *storage* test-entity {:foo 1})
       (client/insert *storage* test-entity {:bar 2})
       (client/insert *storage* test-entity {:baz 3})
-      (client/find *storage* test-entity {$or [{:foo 1} {:bar 2}]})
-        => (just (contains {:foo 1})
-                 (contains {:bar 2}) :in-any-order)))
+      (client/find *storage* test-entity {$or [{:foo 1} {:bar 2}]}) => (just (contains {:foo 1})
+                                                                             (contains {:bar 2}) :in-any-order)))
+
+  (facts "about delete-by-id"
+    (fact "removes single record from database if given ID matches any record"
+      (let [doc (client/insert *storage* test-entity {:foo 1})]
+        (client/delete-by-id *storage* test-entity (:_id doc)) => true))
+
+    (fact "removes single record even if given ID is a string"
+      (let [doc (client/insert *storage* test-entity {:foo 1})
+            doc-id (.toString (:_id doc))]
+        (client/delete-by-id *storage* test-entity doc-id) => true))
+
+    (fact "is false if given string ID is not tied to a record on database"
+      (let [random-id (ObjectId.)]
+        (client/delete-by-id *storage* test-entity (ObjectId.)) => false)))
 
   (facts "about delete"
     (fact "it does not allow deletion without conditions"
       (let [error (client/delete *storage* test-entity {})]
         (fail/message error)=> "Can not delete without conditions"))
 
-    (fact "removes from document records which match conditions"
+    (fact "removes from database records which match conditions"
       (client/insert *storage* test-entity {:foo 1})
       (client/insert *storage* test-entity {:bar 2})
       (client/insert *storage* test-entity {:baz 3})
@@ -122,7 +137,7 @@
       (monger-document/count *db* test-entity {:bar 2}) => 0
       (monger-document/count *db* test-entity {:baz 3}) => 1))
 
-  (fact "returns the number of records deleted"
+  (fact "returns whether any records were removed or not"
     (client/insert *storage* test-entity {:foo 1})
-    (client/delete *storage* test-entity {:bar 2}) => 0
-    (client/delete *storage* test-entity {:foo 1}) => 1))
+    (client/delete *storage* test-entity {:bar 2}) => false
+    (client/delete *storage* test-entity {:foo 1}) => true))

--- a/test/spbus/db/ridership_test.clj
+++ b/test/spbus/db/ridership_test.clj
@@ -1,0 +1,18 @@
+(ns spbus.db.ridership-test
+  (:require [midje.sweet :refer :all]
+            [monger.collection :as monger-document]
+            [spbus.protocols.storage-client :as client]
+            [spbus.db.ridership :as ridership]))
+
+(def *storage* nil)
+(def *db* nil)
+(def test-config {:db-name "test"})
+(def data {:pax 1000})
+
+(fact "Ridership DB repository has its own entity"
+  ridership/entity => "ridership")
+
+;; (fact "about add-ridership"
+;;   (fact "adds a new ridership to storage and return it"
+;;     (ridership/add-ridership ..storage.. data) => {:_id 123 :pax 1000}
+;;     (provided (client/update ..storage.. entity data) => {:_id 123 :pax 1000})))

--- a/test/spbus/db/ridership_test.clj
+++ b/test/spbus/db/ridership_test.clj
@@ -1,18 +1,10 @@
 (ns spbus.db.ridership-test
   (:require [midje.sweet :refer :all]
-            [monger.collection :as monger-document]
+            [spbus.db.ridership :as ridership]
             [spbus.protocols.storage-client :as client]
-            [spbus.db.ridership :as ridership]))
+            [spbus.support.test-tools :as tools]))
 
-(def *storage* nil)
-(def *db* nil)
-(def test-config {:db-name "test"})
-(def data {:pax 1000})
+(tools/init-system!)
 
 (fact "Ridership DB repository has its own entity"
   ridership/entity => "ridership")
-
-;; (fact "about add-ridership"
-;;   (fact "adds a new ridership to storage and return it"
-;;     (ridership/add-ridership ..storage.. data) => {:_id 123 :pax 1000}
-;;     (provided (client/update ..storage.. entity data) => {:_id 123 :pax 1000})))

--- a/test/spbus/db/ridership_test.clj
+++ b/test/spbus/db/ridership_test.clj
@@ -1,10 +1,46 @@
 (ns spbus.db.ridership-test
   (:require [midje.sweet :refer :all]
+            [monger.collection :as monger-data]
             [spbus.db.ridership :as ridership]
             [spbus.protocols.storage-client :as client]
-            [spbus.support.test-tools :as tools]))
+            [spbus.support.test-tools :as tools]
+            [spbus.system-utils :as system-utils]))
 
-(tools/init-system!)
+(def system nil)
+(def storage nil)
 
-(fact "Ridership DB repository has its own entity"
-  ridership/entity => "ridership")
+(def ridership-ent ridership/entity)
+
+(defn setup-system []
+  (let [current-system (tools/init-system!)]
+    (alter-var-root #'system (constantly current-system))
+    (alter-var-root #'storage (constantly (:storage current-system)))
+    (monger-data/remove (:db storage) ridership/entity)))
+
+(defn stop-system []
+  (system-utils/stop-system))
+
+(def bus-normal (tools/mock-from-factory "ridership/bus-normal"))
+
+(with-state-changes [(before :contents (setup-system))
+                     (after :contents (stop-system))]
+  (fact "Ridership DB repository has its own entity"
+    ridership/entity => "ridership")
+
+  (fact "about add-ridership"
+    (ridership/add-ridership storage bus-normal)
+    (client/find storage ridership-ent {}) => (just (contains bus-normal)))
+
+  (fact "ridership-with-id finds a ridership based on its ID"
+    (let [ridership (ridership/add-ridership storage bus-normal)
+          ridership-id (:_id ridership)]
+      (ridership/ridership-with-id storage ridership-id) => (contains bus-normal)))
+
+  (fact "ridership/search-with-text can match records based on its text-searcheable keys"
+    (ridership/add-ridership storage {:company "FOOBAT"})
+    (ridership/add-ridership storage {:stop-name "FOO"})
+    (ridership/add-ridership storage {:line-code "FOO BAR"})
+    (ridership/add-ridership storage {:main-terminus "BAR"})
+    (ridership/text-search storage "foo") => (just (contains {:company "FOOBAT"})
+                                                   (contains {:stop-name "FOO"})
+                                                   (contains {:line-code "FOO BAR"}))))

--- a/test/spbus/support/test_tools.clj
+++ b/test/spbus/support/test_tools.clj
@@ -1,6 +1,6 @@
 (ns spbus.support.test-tools
   (:require [clojure.edn :as edn]
-            [monger.collection :as monger-document]
+            [monger.collection :as monger-data]
             [monger.db :as monger-db]
             [spbus.system-utils :as system-utils]))
 
@@ -24,7 +24,4 @@
     (slurp filename)))
 
 (defn init-system! []
-  (let [system (system-utils/running-system-for-env :test)
-        db (:db (:storage system))]
-    (map #(monger-document/remove db %)
-         (monger-db/get-collection-names db))))
+  (system-utils/running-system-for-env :test))

--- a/test/spbus/support/test_tools.clj
+++ b/test/spbus/support/test_tools.clj
@@ -2,7 +2,7 @@
   (:require [clojure.edn :as edn]
             [monger.collection :as monger-document]
             [monger.db :as monger-db]
-            [spbus.system-utils :as system]))
+            [spbus.system-utils :as system-utils]))
 
 (def factories-path "./test/factories")
 (def fixtures-path "./test/fixtures")
@@ -24,7 +24,7 @@
     (slurp filename)))
 
 (defn init-system! []
-  (let [system (running-system-for-env :test)
+  (let [system (system-utils/running-system-for-env :test)
         db (:db (:storage system))]
     (map #(monger-document/remove db %)
          (monger-db/get-collection-names db))))

--- a/test/spbus/support/test_tools.clj
+++ b/test/spbus/support/test_tools.clj
@@ -1,5 +1,8 @@
 (ns spbus.support.test-tools
-  (:require [clojure.edn :as edn]))
+  (:require [clojure.edn :as edn]
+            [monger.collection :as monger-document]
+            [monger.db :as monger-db]
+            [spbus.system-utils :as system]))
 
 (def factories-path "./test/factories")
 (def fixtures-path "./test/fixtures")
@@ -19,3 +22,9 @@
   [fixture]
   (let [filename (fullpath fixtures-path fixture)]
     (slurp filename)))
+
+(defn init-system! []
+  (let [system (running-system-for-env :test)
+        db (:db (:storage system))]
+    (map #(monger-document/remove db %)
+         (monger-db/get-collection-names db))))

--- a/test/spbus/system_utils_test.clj
+++ b/test/spbus/system_utils_test.clj
@@ -14,8 +14,8 @@
                                              :storage anything})))
 
   (fact "system-utils/stop-system stops the current active system"
-        @system-utils/current-system => nil
-        (system-utils/running-system-for-env :test)
-        (keys (:storage @system-utils/current-system)) => (just #{:config :conn :db}) 
-        (system-utils/stop-system)
-        (keys (:storage @system-utils/current-system)) => (just #{:config})))
+    @system-utils/current-system => nil
+    (system-utils/running-system-for-env :test)
+    (keys (:storage @system-utils/current-system)) => (just #{:config :conn :db})
+    (system-utils/stop-system)
+    @system-utils/current-system => nil))


### PR DESCRIPTION
Refactors
- [x] Update `storage` ns to use `object-id` function whenever an `ObjectId` instance is required - This intends to allow string uids to be used by other functions as well
- [x] Update `storage` so that `delete` implementation returns the just-deleted document, instead of the awkward mongoDB write result
- [x] Update `parser-a` and `parser-b` to include related date on every document parsed
- [x] Rethink how to handle uids in functions that depends on conditions and cannot directly create `ObjectId` instances.